### PR TITLE
Fix devcontainer config, add hostRequirements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,14 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {
-    "ghcr.io/balazs23/devcontainers-features/bazel:1": {}
+  "image": "mcr.microsoft.com/devcontainers/universal:2.3.1",
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
   },
-  "onCreateCommand": ["sudo", "ln", "-s", "bazelisk", "/usr/local/bin/bazel"]
+  "features": {
+    "ghcr.io/balazs23/devcontainers-features/bazel:1.0.1": { 
+      "bazelisk": "v1.15.0"
+    }
+  },
+  "containerEnv": { "USE_BAZEL_VERSION": "6.1.1" }
 }


### PR DESCRIPTION
* Updates to a newer tag of the devcontainer base image
* Adds `hostRequirements` to match the better "free" tier, so you automatically get a better config with one click
* Updates to `1.0.1` of `balasz23/devcontainers-features`
* Specifies `USE_BAZEL_VERSION` and `bazelisk` version for stability.
* Removes `onCreateCommand`, which now fails.

Creating this container fresh will still symlink `bazel` to `bazelisk`, so `bazel version` will work out of the box and use bazelisk. It also pre-fetches the same version indicated in `.bazelversion`.