### PR TITLE
Add cache to prebuild

### DIFF
--- a/.devcontainer/build-caches.sh
+++ b/.devcontainer/build-caches.sh
@@ -1,7 +1,4 @@
-# This file is used for Bazel CI to write the BUILD files for the project.
-
-# You can use it to see the final solutions but note that it will delete your existing
-# BUILD files if you started working.
+#!/bin/bash
 
 # generate java BUILD file
 cat > java/src/main/java/bazel/bootcamp/BUILD <<EOF
@@ -66,20 +63,7 @@ java_grpc_library(
 )
 EOF
 
-
-# write shell test
-cat > tests/BUILD <<EOF
-sh_test(
-    name = "integration_test",
-    srcs = ["integrationtest.sh"],
-    data = [
-        "//go/cmd/server",
-        "//java/src/main/java/bazel/bootcamp:JavaLoggingClient",
-    ],
-)
-EOF
-
-# write WORKSPACE file
-${SHELL} ./generate_workspace.sh
-
 bazel run //:gazelle
+bazel build //...
+git reset --hard
+git clean -f

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,5 +9,6 @@
     "ghcr.io/balazs23/devcontainers-features/bazel:1.0.1": { 
       "bazelisk": "v1.15.0"
     }
-  }
+  },
+  "postCreateCommand": "bash .devcontainer/build-caches.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,5 +10,5 @@
       "bazelisk": "v1.15.0"
     }
   },
-  "postCreateCommand": "bash .devcontainer/build-caches.sh"
+  "onCreateCommand": "bash .devcontainer/build-caches.sh"
 }


### PR DESCRIPTION
This adds a step to run bazel commands as part of the prebuild. End result is that developers running through bootcamp will have several pieces of the local cache preloaded, and we can get through exercises faster.