### PR TITLE
Fix reverse dependency query

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,24 @@
 
 In this exercise, we will experiment with Bazel queries
 
-1.  What are the dependencies for `//proto/logger:logger_proto`?
-    ```
+1. What are the dependencies for `//proto/logger:logger_proto`?
+
+    ```bash
     bazel query 'deps(//proto/logger:logger_proto)'
     ```
 
 1. What targets depend on `//go/cmd/server`?
-    ```
+
+    ```bash
     bazel query 'rdeps(//go/cmd/server,//...)' 
     ```
 
 1. What is the dependency path from `//go/cmd/server` to `//proto/logger:logger_proto`?
 
-    ```
+    ```bash
     bazel query 'somepath(//go/cmd/server,//proto/logger:logger_proto)'
     ```
 
-
 ## Relevant Documentation
+
 - [`bazel query` guide](https://bazel.build/query/guide)

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ In this exercise, we will experiment with Bazel queries
     bazel query 'deps(//proto/logger:logger_proto)'
     ```
 
-1. What targets depend on `//go/cmd/server`?
+1. What targets depend on `//proto/logger:logger_java_proto`?
 
     ```bash
-    bazel query 'rdeps(//go/cmd/server,//...)' 
+    bazel query 'rdeps(//...,//proto/logger:logger_java_proto)'
     ```
 
 1. What is the dependency path from `//go/cmd/server` to `//proto/logger:logger_proto`?

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,10 +91,10 @@ gazelle_dependencies()
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "0aa7df8289c957a4c54cbe694fbabe99b180e64ca0f8fdb5e2f76dcf56ff2422",
-    strip_prefix = "protobuf-21.9",
+    sha256 = "4b98c800b352e7582bc92ed398999030ce4ebb49c7858dcb070850ec476b72f2",
+    strip_prefix = "protobuf-22.5",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/archive/v21.9.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v22.5.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,6 @@
 # gazelle:repository_macro go_deps.bzl%go_deps
 workspace(name = "bootcamp")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -13,13 +14,15 @@ http_archive(
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "8c20f74bca25d2d442b327ae26768c02cf3c99e93fad0381f32be9aab1967675",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
     ],
-    sha256 = "8c20f74bca25d2d442b327ae26768c02cf3c99e93fad0381f32be9aab1967675",
 )
+
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
 rules_pkg_dependencies()
 
 http_archive(
@@ -36,20 +39,21 @@ http_archive(
 # grpc dependencies
 http_archive(
     name = "io_grpc_grpc_java",
+    sha256 = "234440dd7ceb7f6460fc859b0b1fe13d653824adc81e650ae84b0a52185ca342",
+    strip_prefix = "grpc-java-1.58.0",
     urls = [
         "https://github.com/grpc/grpc-java/archive/v1.58.0.tar.gz",
     ],
-    sha256 = "234440dd7ceb7f6460fc859b0b1fe13d653824adc81e650ae84b0a52185ca342",
-    strip_prefix = "grpc-java-1.58.0",
 )
 
 RULES_JVM_EXTERNAL_TAG = "4.5"
+
 RULES_JVM_EXTERNAL_SHA = "b17d7388feb9bfa7f2fa09031b32707df529f26c91ab9e5d909eb1676badd9a6"
 
 http_archive(
     name = "rules_jvm_external",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
@@ -73,8 +77,8 @@ http_archive(
     ],
 )
 
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("//:go_deps.bzl", "go_deps")
 
 go_deps()
@@ -106,7 +110,8 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories", "IO_GRPC_GRPC_JAVA_ARTIFACTS")
+load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "grpc_java_repositories")
+
 grpc_java_repositories()
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
@@ -118,4 +123,5 @@ maven_install(
 )
 
 load("@maven//:compat.bzl", "compat_repositories")
+
 compat_repositories()


### PR DESCRIPTION
- Fix formatting
- Fix reverse dependency query

This change fixes the reverse dependency query as the syntax is:
`rdeps(u, x)`, with:
- `u`: packages to search for targets that depend on `x`
- `x`: target for which reverse dependencies shall be evaluated

After fixing the query, an old bug with missing dependency declaration
in protobuf becomes visible. Thus this change also fixes the missing
dependency by bumping the protobuf version.