### PR TITLE
Update codelab environment for better efficiency

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,4 @@
+common --incompatible_strict_action_env
+common --nostamp
+build  --cxxopt='-std=c++17'
+build  --host_cxxopt='-std=c++17'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,11 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2.3.1",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "hostRequirements": {
     "cpus": 4,
     "memory": "8gb",
     "storage": "32gb"
   },
+  "containerUser": "vscode",
   "features": {
     "ghcr.io/balazs23/devcontainers-features/bazel:1.0.1": { 
       "bazelisk": "v1.15.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,9 @@
   "features": {
     "ghcr.io/balazs23/devcontainers-features/bazel:1.0.1": { 
       "bazelisk": "v1.15.0"
+    },
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "17"
     }
   },
   "onCreateCommand": "bash .devcontainer/build-caches.sh",


### PR DESCRIPTION
* Smaller base image
* Use vscode user to run init script, so we don't lose the cache.

We'll need to rebase to propagate .bazelrc flags.